### PR TITLE
Always run PurgeCSS if the project configures it

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,41 @@ module.exports = {
     "npmdir": "node_modules"
 }
 ```
+
+### Additional config options
+
+#### PurgeCSS
+
+[PurgeCSS](https://purgecss.com/) is a tool to automatically remove unused CSS. webfactory-gulp-preset comes with 
+postcss-purgecss preinstalled, but it is only activated if a `purgeCss` object is defined as a property of the 
+`styles` object in `gulp-config.js`.
+
+All documented options (for the PostCSS implementation) are supported. 
+
+Example (excerpt from `gulp-config.js`):
+
+```js
+// […]
+styles: {
+    files: [
+        {
+            name: 'main.css',
+            files: [
+                'PATH_TO_PROJECT_ASSETS_DIR/scss/main.scss',
+            ],
+            destDir: 'css'
+        }
+    ],
+    purgeCss: {
+        content: [
+            './src/PROJECT_TEMPLATES/**/*.twig',
+            './src/JS_COMPONENTS_THAT_USE_CSS_SELECTORS/**/*.js',
+            './vendor/PACKAGE/TEMPLATES/**/*.twig',
+        ],
+        safelist: ['ANY_VALID_CSS_SELECTOR']
+    },
+    postCssPlugins: postCssPlugins,
+    watch: ['src/**/*.scss']
+},
+// […]
+```

--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -1,6 +1,18 @@
-const $ = require('../plugins')(); /// lädt alle gulp-*-Module in $.*
+const $ = require('../plugins')(); /// load all gulp-*-Modules in $.*
+
+// This custom extractor will also match selectors that contain
+// special chars like "_", ":", "\" and "@"
+class UtilityCssExtractor {
+    static extract(content) {
+        return content.match(/[a-zA-Z0-9-_:@\/]+/g)
+    }
+}
 
 function postCssPlugins(config, stylesheet) {
+    // Grab a PurgeCSS config to use;
+    // always prefers a stylesheet-specific one over a global config for all CSS files
+    let purgeCssConfig = stylesheet.purgeCss || config.styles.purgeCss;
+
     return [
         $.autoprefixer(),
         $.postcssurl({
@@ -10,8 +22,19 @@ function postCssPlugins(config, stylesheet) {
                 }
                 return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/");
             }
-        })
-    ];
+        }),
+        // conditionally run PurgeCSS if any config (local or global) was found
+        purgeCssConfig ? $.purgecss({
+            content: purgeCssConfig.content,
+            extractors: [
+                {
+                    extractor: UtilityCssExtractor,
+                    extensions: ['twig', 'js']
+                }
+            ],
+            safelist: purgeCssConfig.safelist
+        }) : false
+    ].filter(Boolean); // Strip falsy values (this enables conditional plugins like PurgeCSS)
 }
 
 exports.postCssPlugins = postCssPlugins;

--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -2,10 +2,8 @@ const $ = require('../plugins')(); /// load all gulp-*-Modules in $.*
 
 // This custom extractor will also match selectors that contain
 // special chars like "_", ":", "\" and "@"
-class UtilityCssExtractor {
-    static extract(content) {
-        return content.match(/[a-zA-Z0-9-_:@\/]+/g)
-    }
+function utilityCssExtractor(content) {
+    return content.match(/[a-zA-Z0-9-_:@\/]+/g)
 }
 
 function postCssPlugins(config, stylesheet) {
@@ -28,7 +26,7 @@ function postCssPlugins(config, stylesheet) {
             content: purgeCssConfig.content,
             extractors: [
                 {
-                    extractor: UtilityCssExtractor,
+                    extractor: utilityCssExtractor,
                     extensions: ['twig', 'js']
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^3.1.3",
     "autoprefixer": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webfactory-gulp-preset",
   "version": "1.0.5",
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^3.0.0",
+    "@fullhuman/postcss-purgecss": "^3.1.3",
     "autoprefixer": "^10.0.0",
     "browser-sync": "^2.26.7",
     "browserslist-config-webfactory": "^1.0.0",

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -6,7 +6,8 @@ module.exports = function() {
     $['browserSync'] = require('browser-sync').create();
     $['log'] = require('fancy-log');
     $['path'] = require('path');
-    $['postcssurl'] = require("postcss-url");
+    $['postcssurl'] = require('postcss-url');
+    $['purgecss'] = require('@fullhuman/postcss-purgecss');
     $['through2'] = require('through2');
 
     return $;


### PR DESCRIPTION
Make PurgeCSS part of the default PostCSS plugins config, but
conditinally execute it only if the project has a configuration
for a certain stylesheet or a global config for all stylesheets.
Stylesheet-specific configuration takes precedence over global
configuration.