### PR TITLE
Nutze node-sass-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-terser": "^2.0.1",
     "minimist": "^1.2.0",
     "node-sass": "^6.0.1",
+    "node-sass-import": "^2.0.1",
     "postcss": "^8.0.9",
     "postcss-url": "^10.1.3",
     "stylelint": "^14.1.0",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -14,6 +14,7 @@ function styles(gulp, $, config) {
                     cwd: config.webdir,
                     pipeStdout: true,
                     sassOutputStyle: 'nested',
+                    importer: require('node-sass-import'),
                     includePaths: config.styles.includePaths ? config.styles.includePaths : [config.npmdir]
                 }).on('error', $.sass.logError))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))


### PR DESCRIPTION
... um SASS "@import"-Statements automatisch entlang der node_modules-Verzeichnisse aufzulösen, wie es auch der NPM require()-Mechanismus tun würde - und zwar ausgehend von der jeweiligen .scss-Datei.
