### PR TITLE
Fix compatibility with Dart Sass 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ module.exports = {
 
 #### Choose the Sass compiler
 
-For backwards-compatibility reasons, the default compiler is LibSass via node-sass, [which has been deprecated by the Sass project](https://sass-lang.com/blog/libsass-is-deprecated). You can pick the canonical implementation (Dart Sass) by setting `sassCompiler` on the `styles` object in `gulp-config.js`. You will need to install the Dart Sass Node package via npm or yarn (`npm install sass` or `yarn add sass`).
+For backwards-compatibility reasons, the default compiler is LibSass via node-sass, [which has been deprecated by the Sass project](https://sass-lang.com/blog/libsass-is-deprecated). You can pick the canonical implementation (Dart Sass) by setting `sassCompiler` on the `styles` object in `gulp-config.js`. You will need to install the Dart Sass Node package via npm or yarn (`npm install sass-embedded` or `yarn add sass-embedded`).
 
 Example (excerpt from `gulp-config.js`):
 
@@ -119,7 +119,7 @@ styles: {
     files: [
         …
     ],
-    sassCompiler: 'sass', // this passes Dart Sass to gulp-sass
+    sassCompiler: 'sass-embedded', // this is an official version of Dart Sass, optimized for embedded use in NodeJS (faster compile times)
     postCssPlugins: postCssPlugins,
     watch: ['src/**/*.scss']
 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -8,14 +8,22 @@ function styles(gulp, $, config) {
                 return;
             }
 
+            const sassIncludePaths = config.styles.includePaths ? config.styles.includePaths : [config.npmdir];
+            let sassConfig = {
+                cwd: config.webdir,
+                pipeStdout: true,
+                sassOutputStyle: 'nested',
+            };
+
+            if (!config.styles.sassCompiler || config.styles.sassCompiler !== "node-sass") {
+                sassConfig.loadPaths = sassIncludePaths;
+            } else {
+                sassConfig.includePaths = sassIncludePaths;
+            }
+
             return gulp.src(sourceFiles, { cwd: config.webdir })
                 .pipe(config.development ? $.sourcemaps.init() : $.through2.obj())
-                .pipe($.sass({
-                    cwd: config.webdir,
-                    pipeStdout: true,
-                    sassOutputStyle: 'nested',
-                    includePaths: config.styles.includePaths ? config.styles.includePaths : [config.npmdir]
-                }).on('error', $.sass.logError))
+                .pipe($.sass(sassConfig).on('error', $.sass.logError))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))
                 .pipe($.concat(stylesheet.name))
                 .pipe($.cleanCss({


### PR DESCRIPTION
- Address the config property name change to 'loadPaths' when using Dart Sass
- Update README with pointers to use pacakge 'sass-embedded' instead of 'sass' for better compile performance
- Bump version
