### PR TITLE
Emit correct exit code on Sass compilation errors if env != development

### DIFF
--- a/tasks/browsersync.js
+++ b/tasks/browsersync.js
@@ -4,6 +4,11 @@ function browsersync(gulp, $, config, css, js) {
         open: false
     });
 
+    // set a config param to signal browserSync is active;
+    // styles.js will suppress errors for this env to avoid
+    // the watch process exiting on errors
+    config.livereload = true;
+
     gulp.watch(config.styles.watch, { usePolling: true }, css);
     gulp.watch(config.scripts.watch, { usePolling: true }, js);
 }

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -20,7 +20,7 @@ function styles(gulp, $, config) {
                 }).on('error', function(error) {
                     const message = new PluginError('sass', error.messageFormatted).toString();
                     process.stderr.write(`${message}\n`);
-                    config.development ? $.through2.obj() : process.exitCode = 1;
+                    config.livereload ? $.through2.obj() : process.exitCode = 1;
                     done();
                 }))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))


### PR DESCRIPTION
Use hard exit for prod, staging and testing environments (this
is especially important for CI debugging) when Sass encounters
compilation errors. On the other hand, it is useful to only emit
"soft" errors during local development; it would be frustrating
if watch/serve process would crash every time a Sass compilation
is not successful (e.g. because of a typo).
