### PR TITLE
Offer preconfigured SVG optimizations via gulp-svgmin (Case 146144)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-stylelint": "^13.0.0",
+    "gulp-svgmin": "^4.1.0",
     "gulp-terser": "^2.0.1",
     "minimist": "^1.2.0",
     "node-sass": "^7.0.0",

--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -1,19 +1,27 @@
 function svgmin(gulp, $, config) {
     return gulp.src(config.svgo.files, { cwd: config.webdir })
         .pipe($.svgmin({
+            full: true, // needs to be set so that the plugins list is passed directly to SVGO
             plugins: [
                 {
                     name: 'preset-default',
                     params: {
                         overrides: {
+                            // viewBox is required to resize SVGs with CSS.
+                            // @see https://github.com/svg/svgo/issues/1128
                             removeViewBox: false,
+
+                            // title and desc can be used for a11y alternative text (title with aria-labelledby)
                             removeTitle: false,
                             removeDesc: false,
+
+                            // disable task in preset-default, re-enable with custom params below
                             cleanupIDs: false,
                         },
                     }
                 },
                 {
+                    // randomize ID strings to avoid ID collisions of different inline SVGs used on the same page
                     name: 'cleanupIDs',
                     params: {
                         prefix: {
@@ -24,7 +32,6 @@ function svgmin(gulp, $, config) {
                         remove: false,
                     }
                 },
-                'removeXMLNS'
             ],
         }))
         .pipe(gulp.dest(`${config.webdir}/${config.svgo.destDir}`));

--- a/tasks/svgmin.js
+++ b/tasks/svgmin.js
@@ -1,0 +1,33 @@
+function svgmin(gulp, $, config) {
+    return gulp.src(config.svgo.files, { cwd: config.webdir })
+        .pipe($.svgmin({
+            plugins: [
+                {
+                    name: 'preset-default',
+                    params: {
+                        overrides: {
+                            removeViewBox: false,
+                            removeTitle: false,
+                            removeDesc: false,
+                            cleanupIDs: false,
+                        },
+                    }
+                },
+                {
+                    name: 'cleanupIDs',
+                    params: {
+                        prefix: {
+                            toString() {
+                                return `${Math.random().toString(36).substr(2, 9)}`;
+                            }
+                        },
+                        remove: false,
+                    }
+                },
+                'removeXMLNS'
+            ],
+        }))
+        .pipe(gulp.dest(`${config.webdir}/${config.svgo.destDir}`));
+}
+
+exports.svgmin = svgmin;


### PR DESCRIPTION
I decided to **not** strip the `xmlns` here so we can configure a generous parent folder and optimize all SVGs independent of usage. The namespace is required for SVGs that are used via `<img sec />` or CSS `background-image`. I contemplated introducing a specific folder structure with files split into "inline" and "external" folders, but that felt too complicated. My idea now would be we optimize automatically, but remove the namespace attributes manually.