### PR TITLE
Add option to specify selected third-party packages in node_modules to be transpiled with Babel (Case 146461)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,11 @@ const config = require('./gulp-config');
 const $ = require('./node_modules/webfactory-gulp-preset/plugins')(config); // loads all gulp-* modules in $.* for easy reference
 
 
-const { scripts } = require('./node_modules/webfactory-gulp-preset/tasks/scripts');
-const { styles } = require('./node_modules/webfactory-gulp-preset/tasks/styles');
+const { webpack } = require('./node_modules/webfactory-gulp-preset/tasks/webpack');const { styles } = require('./node_modules/webfactory-gulp-preset/tasks/styles');
 const { browsersync } = require('./node_modules/webfactory-gulp-preset/tasks/browsersync');
 
 function js(cb) {
-    scripts(gulp, $, config);
+    webpack(gulp, $, config);
     cb();
 }
 
@@ -65,15 +64,16 @@ module.exports = {
     scripts: {
         files: [
             {
-                name: 'main.js',
-                files: [
+                name: 'main',
+                inputPath: [
                     '../node_modules/some-cool-package/cool-package.min.js',
                     'PATH_TO_PROJECT_ASSETS_DIR/js/my-cool-interactive-feature.js',
                 ],
                 destDir: 'js'
             }
         ],
-         watch: ['PATH_TO_PROJECT_ASSETS_DIR/assets/js/**/*.js'],
+        includeModules: ['module', 'module'], // optional: transpile folder from node_modules
+        watch: ['PATH_TO_PROJECT_ASSETS_DIR/assets/js/**/*.js'],
     },
     styles: {
         files: [

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ const config = require('./gulp-config');
 const $ = require('./node_modules/webfactory-gulp-preset/plugins')(config); // loads all gulp-* modules in $.* for easy reference
 
 
-const { webpack } = require('./node_modules/webfactory-gulp-preset/tasks/webpack');const { styles } = require('./node_modules/webfactory-gulp-preset/tasks/styles');
+const { scripts } = require('./node_modules/webfactory-gulp-preset/tasks/scripts');
+const { styles } = require('./node_modules/webfactory-gulp-preset/tasks/styles');
 const { browsersync } = require('./node_modules/webfactory-gulp-preset/tasks/browsersync');
 
 function js(cb) {
-    webpack(gulp, $, config);
+    scripts(gulp, $, config);
     cb();
 }
 
@@ -64,16 +65,15 @@ module.exports = {
     scripts: {
         files: [
             {
-                name: 'main',
-                inputPath: [
+                name: 'main.js',
+                files: [
                     '../node_modules/some-cool-package/cool-package.min.js',
                     'PATH_TO_PROJECT_ASSETS_DIR/js/my-cool-interactive-feature.js',
                 ],
                 destDir: 'js'
             }
         ],
-        includeModules: ['module', 'module'], // optional: transpile folder from node_modules
-        watch: ['PATH_TO_PROJECT_ASSETS_DIR/assets/js/**/*.js'],
+         watch: ['PATH_TO_PROJECT_ASSETS_DIR/assets/js/**/*.js'],
     },
     styles: {
         files: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -1,5 +1,7 @@
 function webpack(gulp, $, config) {
     let entrypoints = {};
+    let includeModules = config.scripts.includeModules ? '|' + config.scripts.includeModules.join('|') : '';
+
     config.scripts.files.map((script) => {
         entrypoints[script.name] = {
             import: `/${config.webdir}/${script.inputPath}`,
@@ -24,7 +26,7 @@ function webpack(gulp, $, config) {
                 rules: [
                     {
                         test: /(\.m?js?$)|(\.svelte$)/,
-                        exclude: /node_modules\/(?!svelte)/,
+                        exclude: new RegExp('node_modules\\/(?![svelte' + includeModules + '])'),
                         use: {
                             loader: 'babel-loader',
                             options: {


### PR DESCRIPTION
Unter Umständen ist es notwendig, Scripte aus dem `node_modules` Ordner zu transpilieren, um das JS auf alle unterstützten Browsern lauffähig zu machen. Dieser PR ermöglicht das Whitelisten spezifischer Ordner in der Projekt-eigenen `gulp-config.js`.