### PR TITLE
Allow custom paths to be passed to Webpack's module resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,15 @@ module.exports = {
 
 ## Additional config options
 
+### Define custom paths for module resolving
+Webpack has defaults (like `node_modules`, for obvious reasons) for what directories should be searched when resolving modules. It's possible to pass through additional paths to the resolver; this can be helpful if you want to be able to `import` JS files from a Symfony bundle without having to supply a long and fragile relative path. To do so, add the following property to the scripts object:
+`resolveModulesPaths: ['www/bundles']`
+
+In your project's JS file you can now import relative to the symlinked folder, i.e. `import 'webfactoryembed/js/embed.esm.js';`.
+
 ### Transpile packages from `node_modules`
 Due to performance reasons, `node_modules` is excluded from transpiling by default. To ensure backwards-compatibility you can whitelist certain modules from the exclusion. To do so, add the following property to the scripts object:  
-`
-includeModules: ['module_folder_name_1', 'module_folder_name_2']`
+`includeModules: ['module_folder_name_1', 'module_folder_name_2']`
 
 ### SCSS/CSS pipeline
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -3,7 +3,10 @@ function webpack(gulp, $, config) {
     let includeModules = config.scripts.includeModules ? '|' + config.scripts.includeModules.join('|') : '';
 
     // merge and deduplicate arrays; [config.npmdir] is default
-    let resolveModulesPaths = [...new Set([...(config.scripts.resolveModulesPaths ?? []),...[config.npmdir]])];
+    let resolveModulesPaths = [config.npmdir];
+    if (config.scripts.resolveModulesPaths) {
+        resolveModulesPaths = [...new Set([...(config.scripts.resolveModulesPaths), ...resolveModulesPaths])];
+    }
 
     config.scripts.files.map((script) => {
         entrypoints[script.name] = {

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -2,6 +2,9 @@ function webpack(gulp, $, config) {
     let entrypoints = {};
     let includeModules = config.scripts.includeModules ? '|' + config.scripts.includeModules.join('|') : '';
 
+    // merge and deduplicate arrays; [config.npmdir] is default
+    let resolveModulesPaths = [...new Set([...(config.scripts.resolveModulesPaths ?? []),...[config.npmdir]])];
+
     config.scripts.files.map((script) => {
         entrypoints[script.name] = {
             import: `/${config.webdir}/${script.inputPath}`,
@@ -21,6 +24,7 @@ function webpack(gulp, $, config) {
                 },
                 extensions: ['.mjs', '.js', '.svelte'],
                 mainFields: ['svelte', 'browser', 'module', 'main'],
+                modules: resolveModulesPaths,
             },
             module: {
                 rules: [

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -2,9 +2,10 @@ function webpack(gulp, $, config) {
     let entrypoints = {};
     let includeModules = config.scripts.includeModules ? '|' + config.scripts.includeModules.join('|') : '';
 
-    // merge and deduplicate arrays; [config.npmdir] is default
+    // [config.npmdir] is default
     let resolveModulesPaths = [config.npmdir];
     if (config.scripts.resolveModulesPaths) {
+        // merge and deduplicate arrays
         resolveModulesPaths = [...new Set([...(config.scripts.resolveModulesPaths), ...resolveModulesPaths])];
     }
 


### PR DESCRIPTION
- Allow custom paths to be passed to Webpacks module resolver
- Add documentation
