### PR TITLE
Resolve to current major version of clean-css (Case 146359)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "webpack": "^5.47.0",
     "webpack-stream": "^7.0.0"
   },
+  "resolutions": {
+    "clean-css": ">=5.3.1"
+  },
   "browserslist": [
     "extends browserslist-config-webfactory/default"
   ]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "webpack-stream": "^7.0.0"
   },
   "resolutions": {
-    "clean-css": ">=5.3.1"
+    "clean-css": ">=5.3.2"
   },
   "browserslist": [
     "extends browserslist-config-webfactory/default"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -18,10 +18,7 @@ function styles(gulp, $, config) {
                 }).on('error', $.sass.logError))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))
                 .pipe($.concat(stylesheet.name))
-                .pipe($.cleanCss({
-                    compatibility: 'ie9',
-                    rebase: false // machen wir mit postcss-url
-                }))
+                .pipe($.cleanCss({ compatibility: 'ie11' }))
                 .pipe(config.development ? $.sourcemaps.write('.') : $.through2.obj())
                 .pipe(gulp.dest(`${config.webdir}/${stylesheet.destDir}`))
                 .pipe($.browserSync.reload({ stream: true }));


### PR DESCRIPTION
Use Yarn resolution in package.json to require the current
major version of clean-css (unfortunately, gulp-clean-css seems
to be dead with the pertinent PR remaining unmerged since 2021).

clean-css 5.3.2 includes a fix that enables us to use conainer
queries without losing them to CSS minification.

We no longer need to disable URL rebasing as the new default
is `false`.

This seems to be a good time to bump compatibility up to ie11 (the
default is >11 which is still a bit too strict for us in 2023).
