### PR TITLE
Use fork of gulp-clean-css to get current major version of clean-css (Case 146359)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-loader": "^8.2.2",
     "browser-sync": "^2.26.7",
     "browserslist-config-webfactory": "^1.0.0",
+    "clean-css": "^5.3.2",
     "dotenv": "^10.0.0",
     "fancy-log": "^1.3.3",
     "gulp": "^4.0.0",
@@ -34,9 +35,6 @@
     "through2": "^4.0.2",
     "webpack": "^5.47.0",
     "webpack-stream": "^7.0.0"
-  },
-  "resolutions": {
-    "clean-css": ">=5.3.2"
   },
   "browserslist": [
     "extends browserslist-config-webfactory/default"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,11 @@
     "babel-loader": "^8.2.2",
     "browser-sync": "^2.26.7",
     "browserslist-config-webfactory": "^1.0.0",
-    "clean-css": "^5.3.2",
     "dotenv": "^10.0.0",
     "fancy-log": "^1.3.3",
     "gulp": "^4.0.0",
     "gulp-babel": "^8.0.0",
-    "gulp-clean-css": "^4.2.0",
+    "gulp-clean-css": "github:webfactory/gulp-clean-css",
     "gulp-concat": "^2.3.3",
     "gulp-load-plugins": "^2.0.1",
     "gulp-postcss": "^9.0.0",
@@ -35,9 +34,6 @@
     "through2": "^4.0.2",
     "webpack": "^5.47.0",
     "webpack-stream": "^7.0.0"
-  },
-  "resolutions": {
-    "gulp-clean-css/clean-css": "^5.3.2"
   },
   "browserslist": [
     "extends browserslist-config-webfactory/default"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "webpack": "^5.47.0",
     "webpack-stream": "^7.0.0"
   },
+  "resolutions": {
+    "gulp-clean-css/clean-css": "^5.3.2"
+  },
   "browserslist": [
     "extends browserslist-config-webfactory/default"
   ]


### PR DESCRIPTION
This PR builds on #28 but switches us over to a self-maintained fork of gulp-clean-css because Yarn resolutions do not work for transitive dependencies – and we do not want to define resolutions in every project that uses webfactory-gulp-preset.