### PR TITLE
Replace gulp-clean-css with postcss-lightningcss

### DIFF
--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -19,15 +19,6 @@ function postCssPlugins(config, stylesheet) {
     let purgeCss = purgeCssConfig && !purgeCssDisabled;
 
     return [
-        $.autoprefixer(),
-        $.postcssurl({
-            url: function (asset) {
-                if (!asset.url || asset.url.indexOf("base64") !== -1) {
-                    return asset.url;
-                }
-                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/");
-            }
-        }),
         // conditionally run PurgeCSS if any config (local or global) was found
         purgeCss ? $.purgecss({
             content: purgeCssConfig.content,
@@ -38,7 +29,17 @@ function postCssPlugins(config, stylesheet) {
                 }
             ],
             safelist: purgeCssConfig.safelist
-        }) : false
+        }) : false,
+        $.postcssurl({
+            url: function (asset) {
+                if (!asset.url || asset.url.indexOf("base64") !== -1) {
+                    return asset.url;
+                }
+                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/");
+            }
+        }),
+        $.autoprefixer(),
+        $.lightningcss({ sourceMap: false }),
     ].filter(Boolean); // Strip falsy values (this enables conditional plugins like PurgeCSS)
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "minimist": "^1.2.0",
     "node-sass": "^7.0.0",
     "postcss": "^8.0.9",
+    "postcss-lightningcss": "^0.9.0",
     "postcss-url": "^10.1.3",
     "stylelint": "^14.1.0",
     "stylelint-config-sass-guidelines": "^9.0.1",

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -21,6 +21,7 @@ module.exports = function(config) {
     $['log'] = require('fancy-log');
     $['path'] = require('path');
     $['postcssurl'] = require('postcss-url');
+    $['lightningcss'] = require('postcss-lightningcss');
     $['purgecss'] = require('@fullhuman/postcss-purgecss');
     $['through2'] = require('through2');
     $['webpack'] = require('webpack');

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -18,7 +18,6 @@ function styles(gulp, $, config) {
                 }).on('error', $.sass.logError))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))
                 .pipe($.concat(stylesheet.name))
-                .pipe($.cleanCss({ compatibility: 'ie11' }))
                 .pipe(config.development ? $.sourcemaps.write('.') : $.through2.obj())
                 .pipe(gulp.dest(`${config.webdir}/${stylesheet.destDir}`))
                 .pipe($.browserSync.reload({ stream: true }));


### PR DESCRIPTION
This is a continuation of the problem-solving started in #28 and #29. 

gulp-clean-css has probably become stale (with its author completely unresponsive), and while clean-css still is the most downloaded CSS minification package on npm, its author has put the project into ["maintenance mode"](https://github.com/clean-css/clean-css/discussions/1209) and will no longer actively work on it.

Addendum June 2025: [gulp-clean-css seems to completely remove Cascade Layers](https://github.com/scniro/gulp-clean-css/issues/92)

[LightningCSS](https://lightningcss.dev/) is a modern take on CSS minification and extremely fast. 

Downsides (if used as a postcss plugin):
-  SCSS sourcemaps are lost

As it is logical to first purge unused CSS before performing any other transformations on the remaining code, the order of the postcss plugins is adjusted accordingly.

