### PR TITLE
Replace gulp-clean-css with gulp-csso (Case 161784)

### DIFF
--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -19,15 +19,6 @@ function postCssPlugins(config, stylesheet) {
     let purgeCss = purgeCssConfig && !purgeCssDisabled;
 
     return [
-        $.autoprefixer(),
-        $.postcssurl({
-            url: function (asset) {
-                if (!asset.url || asset.url.indexOf("base64") !== -1) {
-                    return asset.url;
-                }
-                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/");
-            }
-        }),
         // conditionally run PurgeCSS if any config (local or global) was found
         purgeCss ? $.purgecss({
             content: purgeCssConfig.content,
@@ -38,7 +29,16 @@ function postCssPlugins(config, stylesheet) {
                 }
             ],
             safelist: purgeCssConfig.safelist
-        }) : false
+        }) : false,
+        $.postcssurl({
+            url: function (asset) {
+                if (!asset.url || asset.url.indexOf("base64") !== -1) {
+                    return asset.url;
+                }
+                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/");
+            }
+        }),
+        $.autoprefixer(),
     ].filter(Boolean); // Strip falsy values (this enables conditional plugins like PurgeCSS)
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "github:webfactory/gulp-clean-css",
     "gulp-concat": "^2.3.3",
+    "gulp-csso": "^4.0.1",
     "gulp-load-plugins": "^2.0.1",
     "gulp-postcss": "^9.0.0",
     "gulp-sass": "^5.0.0",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -18,7 +18,7 @@ function styles(gulp, $, config) {
                 }).on('error', $.sass.logError))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))
                 .pipe($.concat(stylesheet.name))
-                .pipe($.cleanCss({ compatibility: 'ie11' }))
+                .pipe($.csso({ sourceMap: true }))
                 .pipe(config.development ? $.sourcemaps.write('.') : $.through2.obj())
                 .pipe(gulp.dest(`${config.webdir}/${stylesheet.destDir}`))
                 .pipe($.browserSync.reload({ stream: true }));


### PR DESCRIPTION
This is a continuation of the problem-solving started in #28 and #29. 

gulp-clean-css has probably become stale (with its author completely unresponsive), and while clean-css still is the most downloaded CSS minification package on npm, its author has put the project into ["maintenance mode"](https://github.com/clean-css/clean-css/discussions/1209) and will no longer actively work on it.

Addendum June 2025: [gulp-clean-css seems to completely remove Cascade Layers](https://github.com/scniro/gulp-clean-css/issues/92)

[CSSO](https://github.com/css/csso) is a CSS minifier that has been around almost as long (since 2015) as clean-css (since 2011). Minification is significantly faster than clean-css.

Downsides:
- postcss-csso has a [bug](https://github.com/lahmatiy/postcss-csso/issues/26) with container queries (open since 2022, not fixed 2025-02-25)
- gulp-csso works well, but prolongs our dependence on gulp
- fast, but not as fast as lightningcss

As it is logical to first purge unused CSS before performing any other transformations on the remaining code, the order of the postcss plugins is adjusted accordingly.
