### PR TITLE
Add PHP and SVG files to PurgeCSS selector extractor

### DIFF
--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -25,7 +25,7 @@ function postCssPlugins(config, stylesheet) {
             extractors: [
                 {
                     extractor: utilityCssExtractor,
-                    extensions: ['twig', 'js']
+                    extensions: ['php', 'twig', 'js', 'svg']
                 }
             ],
             safelist: purgeCssConfig.safelist


### PR DESCRIPTION
Let PurgeCSS also check PHP and SVG files for CSS classes if their paths are passed to `purgecss content`.