### PR TITLE
Prepare Webpack task for compiling Svelte 4+ apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,13 @@ styles: {
 ### JS pipeline
 
 #### Svelte
-The Webpack Gulp task is preconfigured for compiling Svelte apps, but you need to require `svelte-loader` as a direct dependency in your project to make it work. Specify the entry point (.js file) as any other in `gulp-config.js`, and Webpack will auto-detect Svelte and know what to do.
+The Webpack Gulp task is preconfigured for compiling Svelte apps, but you need to require `svelte` and `svelte-loader` as a direct dependencies in your project to make it work. 
+
+Specify 
+- the `svelteVersion` as a first-level property (string or number) in `gulp-config.js`, e.g. `svelteVersion: '^4.2'`; the path to Svelte internals changed in v4 which is why the project needs to supply the Svelte version that is in use. If no `svelteVersion` is provided, this preset defaults to settings for version 3. 
+- the entry point (.js file) as any other in `gulp-config.js`, 
+
+and Webpack will auto-detect Svelte and know what to do.
 
 #### Custom paths for module resolving
 Webpack has defaults (like `node_modules`, for obvious reasons) for what directories should be searched when resolving modules. It's possible to pass through additional paths to the resolver; this can be helpful if you want to be able to `import` JS files from a Symfony bundle without having to supply a long and fragile relative path. To do so, add the following property to the scripts object:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.8",

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -1,6 +1,7 @@
 function webpack(gulp, $, config) {
     let entrypoints = {};
     let includeModules = config.scripts.includeModules ? '|' + config.scripts.includeModules.join('|') : '';
+    let svelteVersion = config.svelteVersion ? parseFloat(config.svelteVersion) : 3;
 
     // [config.npmdir] is default
     let resolveModulesPaths = [config.npmdir];
@@ -24,7 +25,7 @@ function webpack(gulp, $, config) {
             },
             resolve: {
                 alias: {
-                    svelte: $.path.resolve('node_modules', 'svelte')
+                    svelte: svelteVersion < 4 ? $.path.resolve('node_modules', 'svelte') : $.path.resolve('node_modules', 'svelte/src/runtime')
                 },
                 extensions: ['.mjs', '.js', '.svelte'],
                 mainFields: ['svelte', 'browser', 'module', 'main'],


### PR DESCRIPTION
Svelte 4 requires a differend directory path for the webpack alias.