### PR TITLE
Add Babel Plugin for async/await in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.0",
   "dependencies": {
     "@babel/core": "^7.13.8",
+    "@babel/plugin-transform-runtime": "^7.25.9",
     "@babel/preset-env": "^7.13.8",
     "@fullhuman/postcss-purgecss": "^4.0.3",
     "babel-loader": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/plugin-transform-runtime": "^7.25.9",

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -41,6 +41,7 @@ function webpack(gulp, $, config) {
                             options: {
                                 cacheDirectory: true,
                                 presets: ['@babel/preset-env'],
+                                plugins: ["@babel/plugin-transform-runtime"],
                             }
                         }
                     },


### PR DESCRIPTION
This is needed for async functions in development, at least within Svelte apps like the DSAR "Beratungstool", where the browser will throw an error ("regeneratorRuntime is not defined") unless Webpack compiles for production environment.
