### PR TITLE
Exit Sass task with error code if any stylesheet does not compile successfully

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/plugin-transform-runtime": "^7.25.9",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -15,7 +15,11 @@ function styles(gulp, $, config) {
                     pipeStdout: true,
                     sassOutputStyle: 'nested',
                     includePaths: config.styles.includePaths ? config.styles.includePaths : [config.npmdir]
-                }).on('error', $.sass.logError))
+                }).on('error', function(error) {
+                    console.error('Sass Error:', error.messageFormatted);
+                    process.exitCode = 1;
+                    this.emit('end');
+                }))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))
                 .pipe($.concat(stylesheet.name))
                 .pipe($.cleanCss({ compatibility: 'ie11' }))


### PR DESCRIPTION
The default handling of gulp-sass is to only log an error but not interrupt the Gulp stream; however, we want to bubble the error to the outside environment so a CI Build and Deployment will fail on Sass errors.
