### PR TITLE
Preserve hashes when rebasing urls

### DIFF
--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -36,7 +36,7 @@ function postCssPlugins(config, stylesheet) {
                 if (!asset.url || asset.url.indexOf("base64") !== -1) {
                     return asset.url;
                 }
-                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/") + (asset.hash ? asset.hash : '');
+                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/") + asset.hash;
             }
         }),
     ].filter(Boolean); // Strip falsy values (this enables conditional plugins like PurgeCSS)

--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -36,6 +36,9 @@ function postCssPlugins(config, stylesheet) {
                 if (!asset.url || asset.url.indexOf("base64") !== -1) {
                     return asset.url;
                 }
+                if (asset.url === asset.hash) {
+                    return asset.hash;
+                }
                 return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/") + asset.hash;
             }
         }),

--- a/config/postcss-plugins-default.js
+++ b/config/postcss-plugins-default.js
@@ -36,7 +36,7 @@ function postCssPlugins(config, stylesheet) {
                 if (!asset.url || asset.url.indexOf("base64") !== -1) {
                     return asset.url;
                 }
-                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/");
+                return $.path.relative(`${config.webdir}/${stylesheet.destDir}/`, asset.absolutePath).split("\\").join("/") + (asset.hash ? asset.hash : '');
             }
         }),
     ].filter(Boolean); // Strip falsy values (this enables conditional plugins like PurgeCSS)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "dependencies": {
     "@babel/core": "^7.13.8",
     "@babel/plugin-transform-runtime": "^7.25.9",


### PR DESCRIPTION
Fixes two bugs when working with hashes in `url()` values of properties in CSS: 

1. Adding the hash to the final path string by default. This is safe, because the hash property of the asset object is either the hash itself or an empty string. This makes working with hashes possible in the first place.
2. When referencing inlined resources by a hash, the default path string is no longer added, which resulted in not beeing able to reference inline resources at all. 