### PR TITLE
Support TypeScript files as bundle sources (Case 199344)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "stylelint-order": "^5.0.0",
     "terser": "^5.3.8",
     "through2": "^4.0.2",
+    "ts-loader": "^9.5.4",
     "webpack": "^5.47.0",
     "webpack-stream": "^7.0.0"
   },

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -27,7 +27,7 @@ function webpack(gulp, $, config) {
                 alias: {
                     svelte: svelteVersion < 4 ? $.path.resolve('node_modules', 'svelte') : $.path.resolve('node_modules', 'svelte/src/runtime')
                 },
-                extensions: ['.mjs', '.js', '.svelte'],
+                extensions: ['.mjs', '.js', '.svelte', '.ts'],
                 mainFields: ['svelte', 'browser', 'module', 'main'],
                 modules: resolveModulesPaths,
             },
@@ -66,6 +66,11 @@ function webpack(gulp, $, config) {
                             fullySpecified: false
                         }
                     },
+                    {
+                        test: /\.tsx?$/,
+                        use: 'ts-loader',
+                        exclude: /node_modules/,
+                    }
                 ]
             },
             plugins: [


### PR DESCRIPTION
Adds support for TypeScript files to the Webpack bundling task.

The gulp task including the modifications from this PR is already in use in https://github.com/webfactory/webfactory-de-projekt-controlling/blob/3a61cad789bc893c8fd406b279a0d4bd57b86e90/webpack-ts.js, which can be set back to using the upstream task after this has been merged.

Apart from being necessary for our Projekt Controlling app, I'd like to make it easier to use TypeScript in webfactory projects to encourage its use.

It might be "cleaner" to open the gulp preset for downstream Webpack config modifications rather than adding TypeScript upstream. However, this is already how we decided to handle Svelte support, which is used by a similarly small amount of webfactory projects, and it seems to be easier right now – the downsides of requiring TypeScript upstream should not be this big, given this is just a dev dependency.

That doesn't mean I wouldn't be positive designing an interface for additional webpack configuration from downstream, and maybe bringing the syntax expected in `gulp-config.js` closer to the well documented Webpack config format.