### PR TITLE
Teste gulp-sass Version 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-concat": "^2.3.3",
     "gulp-load-plugins": "^2.0.1",
     "gulp-postcss": "^9.0.0",
-    "gulp-sass": "^5.0.0",
+    "gulp-sass": "^6.0.1",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-stylelint": "^13.0.0",
     "gulp-svgmin": "^4.1.0",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -13,16 +13,17 @@ function styles(gulp, $, config) {
                 .pipe($.sass({
                     cwd: config.webdir,
                     pipeStdout: true,
-                    sassOutputStyle: 'nested',
-                    includePaths: config.styles.includePaths ? config.styles.includePaths : [config.npmdir]
-                }).on('error', function(error) {
+                    style: 'expanded',
+                    importers: [new $.sass.compiler.NodePackageImporter(config.webdir)],
+                    loadPaths: config.styles.includePaths ? config.styles.includePaths : [config.npmdir]
+                }, true).on('error', function(error) {
                     console.error('Sass Error:', error.messageFormatted);
                     process.exitCode = 1;
                     this.emit('end');
                 }))
                 .pipe($.postcss(config.styles.postCssPlugins(config, stylesheet)))
                 .pipe($.concat(stylesheet.name))
-                .pipe($.cleanCss({ compatibility: 'ie11' }))
+                // .pipe($.cleanCss({ compatibility: 'ie11' }))
                 .pipe(config.development ? $.sourcemaps.write('.') : $.through2.obj())
                 .pipe(gulp.dest(`${config.webdir}/${stylesheet.destDir}`))
                 .pipe($.browserSync.reload({ stream: true }));


### PR DESCRIPTION
## ⚠️ Achtung: `NodePackageImporter()` benötigt Entrypoint

[Eigentlich sollte `entryPointDirectory` beim Ruf des Konstruktors optional sein](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/#constructor); bei Nutzung mit gulp-sass in https://github.com/mpdude/yarn-dependency-test/pull/7 kommen aber Fehler, wenn man ihn weglässt:

```
Sass Error: www/bundles/app/scss/test.scss
Can't find stylesheet to import.
  ╷
1 │ @use "pkg:dies-das/style.scss";
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  - 1:1  root stylesheet
  ```