### PR TITLE
Update all Babel-related packages and add missing dependency `@babel/runtime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "webfactory-gulp-preset",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "dependencies": {
-    "@babel/core": "^7.13.8",
-    "@babel/plugin-transform-runtime": "^7.25.9",
-    "@babel/preset-env": "^7.13.8",
+    "@babel/core": "^7.28.5",
+    "@babel/plugin-transform-runtime": "^7.28.5",
+    "@babel/preset-env": "^7.28.5",
+    "@babel/runtime": "^7.28.4",
     "@fullhuman/postcss-purgecss": "^4.0.3",
-    "babel-loader": "^8.2.2",
+    "babel-loader": "^10.0.0",
     "browser-sync": "^2.26.7",
     "browserslist-config-webfactory": "^1.0.0",
     "dotenv": "^10.0.0",
@@ -32,7 +33,7 @@
     "terser": "^5.3.8",
     "through2": "^4.0.2",
     "ts-loader": "^9.5.4",
-    "webpack": "^5.47.0",
+    "webpack": "^5.103.0",
     "webpack-stream": "^7.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
This fixes JS bundling errors when a new install is downloading current Babel releases. The dependency `@babel/runtime` should have been added in #42 as the [documentation](https://babeljs.io/docs/babel-plugin-transform-runtime) clearly states that it is needed; however, until now we observed no errors (neither at compile time nor with functionality on websites).